### PR TITLE
introduced timilimit_hard and max_ncpus_hard in the qadapter to enabl…

### DIFF
--- a/pymatgen/io/abinitio/pseudos.py
+++ b/pymatgen/io/abinitio/pseudos.py
@@ -1900,11 +1900,18 @@ class PseudoTable(six.with_metaclass(abc.ABCMeta, collections.Sequence, PMGSONab
             names.append(p.basename)
 
             # FIXME
-            ecut_acc = dict(
-                low=report.ecuts[0],
-                normal=report.ecuts[4],
-                high=report.ecuts[-1],
-            )
+            try:
+                ecut_acc = dict(
+                    low=report.ecuts[0],
+                    normal=report.ecuts[4],
+                    high=report.ecuts[-1],
+                )
+            except IndexError:
+                ecut_acc = dict(
+                    low=report.ecuts[0],
+                    normal=report.ecuts[-1],
+                    high=report.ecuts[-1],
+                )
 
             for acc in accuracies:
                 d[acc + "_ecut"] = ecut_acc[acc]

--- a/pymatgen/io/abinitio/qadapters.py
+++ b/pymatgen/io/abinitio/qadapters.py
@@ -454,7 +454,7 @@ limits:
         self.set_timelimit_hard(qu.timelimit_parser(d.pop("timelimit_hard")))
         self.min_cores = int(d.pop("min_cores", 1))
         self.max_cores = int(d.pop("max_cores"))
-        self.max_cores_hard = int(d.pop("max_cores_hard"))  # hard limit
+        self.max_cores_hard = int(d.pop("max_cores_hard", self.max_cores))
         # FIXME: Neeed because autoparal 1 with paral_kgb 1 is not able to estimate memory 
         self.min_mem_per_proc = qu.any2mb(d.pop("min_mem_per_proc", self.hw.mem_per_core))
         self.max_mem_per_proc = qu.any2mb(d.pop("max_mem_per_proc", self.hw.mem_per_node))

--- a/pymatgen/io/abinitio/qadapters.py
+++ b/pymatgen/io/abinitio/qadapters.py
@@ -994,7 +994,7 @@ limits:
             self.hint_cores = new_cores
             return new_cores
 
-        raise self.Error('more_cores reached the limit')
+        raise self.Error('%s hint_cores reached limit on max_core %s' % (new_cores, self.max_cores))
 
     def more_time(self, factor=1):
         """

--- a/pymatgen/io/abinitio/qadapters.py
+++ b/pymatgen/io/abinitio/qadapters.py
@@ -454,7 +454,7 @@ limits:
         self.set_timelimit_hard(qu.timelimit_parser(d.pop("timelimit_hard")))
         self.min_cores = int(d.pop("min_cores", 1))
         self.max_cores = int(d.pop("max_cores"))
-        self.max_cores_hard = int(d.pop("max_cores_hard"))
+        self.max_cores_hard = int(d.pop("max_cores_hard"))  # hard limit
         # FIXME: Neeed because autoparal 1 with paral_kgb 1 is not able to estimate memory 
         self.min_mem_per_proc = qu.any2mb(d.pop("min_mem_per_proc", self.hw.mem_per_core))
         self.max_mem_per_proc = qu.any2mb(d.pop("max_mem_per_proc", self.hw.mem_per_node))

--- a/pymatgen/io/abinitio/tasks.py
+++ b/pymatgen/io/abinitio/tasks.py
@@ -892,7 +892,7 @@ batch_adapter:
             self.qadapter.more_mem_per_proc()
         except QueueAdapterError:
             # here we should try to switch to an other qadapter
-            raise ManagerIncreaseError
+            raise ManagerIncreaseError('manager failed to increase mem')
 
     def increase_ncpu(self):
         """
@@ -907,7 +907,7 @@ batch_adapter:
 
     def increase_resources(self):
         try:
-            self.qadapter.more_mpi_procs
+            self.qadapter.more_cores()
         except QueueAdapterError:
             pass
 

--- a/pymatgen/io/abinitio/tasks.py
+++ b/pymatgen/io/abinitio/tasks.py
@@ -788,7 +788,7 @@ batch_adapter:
         Maximum number of cores that can be used.
         This value is mainly used in the autoparal part to get the list of possible configurations.
         """
-        return max(q.max_cores for q in self.qads)
+        return max(q.hint_cores for q in self.qads)
 
     def get_njobs_in_queue(self, username=None):
         """
@@ -900,7 +900,7 @@ batch_adapter:
         switch to the next qadapter. If all fail raise an ManagerIncreaseError
         """
         try:
-            self.qadapter.more_mpi_procs
+            self.qadapter.more_cores()
         except QueueAdapterError:
             # here we should try to switch to an other qadapter
             raise ManagerIncreaseError('manager failed to increase ncpu')
@@ -2145,7 +2145,6 @@ class Task(six.with_metaclass(abc.ABCMeta, Node)):
         self.start(*args, **kwargs)
         retcode = self.wait()
         return retcode
-
 
 
 class DecreaseDemandsError(Exception):

--- a/pymatgen/io/abinitio/tasks.py
+++ b/pymatgen/io/abinitio/tasks.py
@@ -53,7 +53,6 @@ __all__ = [
 import logging
 logger = logging.getLogger(__name__)
 
-
 # Tools and helper functions.
 
 def straceback():


### PR DESCRIPTION
…e abipy to change the timelimit and max_ncpus to fix qcritical problems. the _hard limits should be that values from which the resource manager does not accept the job anymore, the normal ones are the inintial values at which the first setup is generated